### PR TITLE
xi3.s.age - how long since we received fresh data from the car

### DIFF
--- a/vehicle/OVMS.V3/components/vehicle_bmwi3/docs/index.rst
+++ b/vehicle/OVMS.V3/components/vehicle_bmwi3/docs/index.rst
@@ -98,6 +98,7 @@ Custom metrics
 ======================================== =================== =====================================================================================================
 Metric name                              Example value       Description
 ======================================== =================== =====================================================================================================
+xi3.s.age                                5Min                How long since we last got data from the car
 xi3.s.pollermode                         0                   OBD-II polling mode as explained above
 xi3.v.b.p.ocv.avg                        4.0646V             Main battery pack - average open-circuit voltage
 xi3.v.b.p.ocv.max                        4.067V              Main battery pack - highest open-circuit voltage

--- a/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.h
+++ b/vehicle/OVMS.V3/components/vehicle_bmwi3/src/vehicle_bmwi3.h
@@ -80,8 +80,10 @@ class OvmsVehicleBMWi3 : public OvmsVehicle
     int framecount = 0, tickercount = 0, replycount = 0;  // Keep track of when the car is talking or schtum.
     int eps_messages = 0;                                 // Is the EPS (power steering) alive?  If so we are "on"
     int pollerstate;                                      // What pollerstate we are in
+    int last_obd_data_seen;                               // "monotonic" value last time we saw data
 
     // Local metrics
+    // Wheel speeds
     OvmsMetricFloat *mt_i3_wheel1_speed;
     OvmsMetricFloat *mt_i3_wheel2_speed;
     OvmsMetricFloat *mt_i3_wheel3_speed;
@@ -136,6 +138,7 @@ class OvmsVehicleBMWi3 : public OvmsVehicle
     // State
     OvmsMetricBool *mt_i3_obdtraffic;
     OvmsMetricInt *mt_i3_pollermode;
+    OvmsMetricInt *mt_i3_age;
 
     void IncomingPollReply(canbus* bus, uint16_t type, uint16_t pid, uint8_t* data, uint8_t length, uint16_t mlremain);
   };


### PR DESCRIPTION
xi3.s.age stores the number of minutes since we last collected data from the car.

This allows you to see how long the car has been asleep and how
stale car metrics are.